### PR TITLE
Fix: Make entire TabItem clickable

### DIFF
--- a/Utils/Controls/SharedTabControlStyle.xaml
+++ b/Utils/Controls/SharedTabControlStyle.xaml
@@ -58,7 +58,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TabItem">
-                    <Grid x:Name="templateRoot">
+                    <Grid x:Name="templateRoot" Background="Transparent">
                         <Border x:Name="TabBorder"
                                 BorderBrush="{DynamicResource TabItemBorderBrush}"
                                 BorderThickness="{DynamicResource TabItemBorderThickness}"


### PR DESCRIPTION
I modified the ControlTemplate of SharedTabItemStyle in Utils/Controls/SharedTabControlStyle.xaml. I set the Background property of the Grid element named templateRoot to Transparent.

This change ensures that the entire area of a TabItem is hit-testable, allowing you to click anywhere on the tab to select it, not just on the text content. This improves usability and provides a more intuitive user experience.

The SharedTabItemStyle is used by TabControls in Assistant/MainFrame.xaml and Reader/UserControls/ReaderUserControl.xaml, so this change will affect TabItems in both areas.